### PR TITLE
Adapt webpack regex for Windows

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -104,7 +104,7 @@ module.exports = (env, options) => {
       module: {
         rules: [
           {
-            test: /\/css\/site\/.*\.css$/,
+            test: /[\\\/]css[\\\/]site[\\\/].*\.css$/,
             use: [
               MiniCssExtractPlugin.loader,
               {


### PR DESCRIPTION
Makes Webpack play nice with Windows-style paths. According to the solution found [here](https://github.com/webpack/webpack/issues/2073).