### PR TITLE
Add conditional for tippy template attribute

### DIFF
--- a/tailoff/js/components/tooltip.component.ts
+++ b/tailoff/js/components/tooltip.component.ts
@@ -2,7 +2,7 @@ import tippy from 'tippy.js';
 
 export class TooltipComponent {
   constructor() {
-    if (document.querySelectorAll('[data-tippy-content]').length > 0) {
+    if (document.querySelectorAll('[data-tippy-content]').length > 0 || document.querySelectorAll('[data-tippy-template]').length > 0) {
       this.initTippy();
     }
   }


### PR DESCRIPTION
Added an extra condition so when there is only a [data-tippy-template] attribute on the page, the tooltip component gets fired as well.