### PR TITLE
Add clear-caches to post-deploy-craft3 script.

### DIFF
--- a/post-deploy-craft3.sh
+++ b/post-deploy-craft3.sh
@@ -57,6 +57,7 @@ executeCommand "composer install --no-dev" "Installing composer requirements..."
 executeCommand "chmod +x ./craft"
 executeCommand "./craft migrate/all"
 executeCommand "./craft project-config/apply"
+executeCommand "./craft clear-caches/all"
 
 FILE="config/htaccess-$ENVIRONMENT"
 if [ -f $FILE ]; then


### PR DESCRIPTION
Ik was aan het lezen over de best practices ivm het clearen van caches bij het deployen omdat we bij een project even wat rare resultaten kregen na een deploy en het probleem foutieve caches bleek te zijn.

Op deze pagina van craftcms zelf raden ze aan om bij elke deploy de caches te clearen

https://craftcms.com/knowledge-base/deployment-best-practices

Ik vond ook dit advies terug op de stack overflow van craft dat ik heel duidelijk vond. 

https://craftcms.stackexchange.com/a/39557