### PR TITLE
[StatikVariable] paginate function should return consistent return type

### DIFF
--- a/modules/statik/src/variables/StatikVariable.php
+++ b/modules/statik/src/variables/StatikVariable.php
@@ -16,26 +16,22 @@ class StatikVariable
 {
     /**
      * Render pagination template with options
-     * @param Paginate $pageInfo
-     * @param array $options
-     * @return null
+     * @param array $options to pass to the template
      * @throws \Twig\Error\LoaderError
      * @throws \Twig\Error\RuntimeError
      * @throws \Twig\Error\SyntaxError
      * @throws \yii\base\Exception
      */
-    public function paginate(Paginate $pageInfo, array $options = [])
+    public function paginate(Paginate $pageInfo, array $options = []): string
     {
         if (!$pageInfo->total) {
-            return false;
+            return '';
         }
 
-        echo Craft::$app->view->renderTemplate('_site/_snippet/_global/_paginate', [
+        return Craft::$app->view->renderTemplate('_site/_snippet/_global/_paginate', [
             'pageInfo' => $pageInfo,
             'options' => $options,
         ],View::TEMPLATE_MODE_SITE);
-
-        return null;
     }
 
     public function isBot($userAgent = '/bot|crawl|facebook|google|slurp|spider|mediapartners/i')

--- a/templates/_site/_news/_index.twig
+++ b/templates/_site/_news/_index.twig
@@ -17,9 +17,7 @@
                 {% endfor %}
             </div>
 
-            {{ craft.statik.paginate(pageInfo, {
-                pageRange: 2
-            }) }}
+            {{ craft.statik.paginate(pageInfo, { pageRange: 2 }) | raw}}
 
         </div>
     </div>

--- a/templates/jsPlugins/ajaxPaging.twig
+++ b/templates/jsPlugins/ajaxPaging.twig
@@ -39,7 +39,7 @@
                 {% endfor %}
             </div>
             <div class="flex justify-center mt-10 js-ajax-paging-links">
-                {{ craft.statik.paginate(pageInfoNews) }}
+                {{ craft.statik.paginate(pageInfoNews) | raw }}
             </div>
         </div>
     </div>
@@ -60,7 +60,7 @@
                 {% endfor %}
             </div>
             <div class="flex justify-center mt-10 js-ajax-paging-links">
-                {{ craft.statik.paginate(pageInfoNews2) }}
+                {{ craft.statik.paginate(pageInfoNews2) | raw }}
             </div>
         </div>
     </div>

--- a/templates/jsPlugins/filter.twig
+++ b/templates/jsPlugins/filter.twig
@@ -202,7 +202,7 @@
                                         pageRange: 2,
                                         prevText: '«',
                                         nextText: '»'
-                                    }) }}
+                                    }) | raw }}
                                 </div>
                             {% endif %}
                         </div>

--- a/templates/jsPlugins/filterButton.twig
+++ b/templates/jsPlugins/filterButton.twig
@@ -90,7 +90,7 @@
                                 pageRange: 2,
                                 prevText: '«',
                                 nextText: '»'
-                                }) }}
+                                }) | raw }}
                             </div>
                         {% endif %}
                     </div>


### PR DESCRIPTION
De paginate function zou beter een consistent return type hebben om mee te werken. Op deze manier kan je het resultaat ook in een variabele steken moest je er nog iets van manipulatie op moeten doen. 