### PR TITLE
Change the getOptions function in the autocomplete component to this.

### DIFF
--- a/tailoff/js/components/autocomplete.component.ts
+++ b/tailoff/js/components/autocomplete.component.ts
@@ -746,6 +746,15 @@ class Autocomplete {
   }
 
   private getOptions(value) {
-    return this.options.filter((o) => o.text.trim().toLowerCase().indexOf(value.toLowerCase()) > -1);
+    return this.options.filter(
+      (o) =>
+        o.text.trim().toLowerCase().indexOf(value.toLowerCase()) > -1 ||
+        o.text
+          .trim()
+          .normalize('NFD')
+          .replace(/[\u0300-\u036f]/g, '')
+          .toLowerCase()
+          .indexOf(value.toLowerCase()) > -1
+    );
   }
 }


### PR DESCRIPTION
Fixes #112
Makes the search in the autocomplete ignore accents for an easier search.