### PR TITLE
Fix for vimeo urls that are formatted like https://vimeo.com/834728934/3fb1f201e9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "statikbe/craft-cookie-banner": "3.0.3",
     "statikbe/craft-cta-field": "^2.0.0",
     "statikbe/craft-translate": "^2.0.0",
-    "statikbe/craft-video-parser": "^2.0.0",
+    "statikbe/craft-video-parser": "^2.1.1",
     "studioespresso/craft-dumper": "3.0.1",
     "studioespresso/craft-navigate": "3.1.3",
     "studioespresso/craft-seo-fields": "3.3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a5d555cec6cca9d9fb1728650b76fda3",
+    "content-hash": "3db9f785bc36045bde31db14881269d4",
     "packages": [
         {
             "name": "born05/craft-assetusage",
@@ -4397,16 +4397,16 @@
         },
         {
             "name": "statikbe/craft-video-parser",
-            "version": "2.1.0",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/statikbe/craft-video-parser.git",
-                "reference": "70d7599dd29cc35c8fa38123eb54535a1f4f7f78"
+                "reference": "2afb87b740cb5c8bbfb72a27dbbe271b358d0d85"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/statikbe/craft-video-parser/zipball/70d7599dd29cc35c8fa38123eb54535a1f4f7f78",
-                "reference": "70d7599dd29cc35c8fa38123eb54535a1f4f7f78",
+                "url": "https://api.github.com/repos/statikbe/craft-video-parser/zipball/2afb87b740cb5c8bbfb72a27dbbe271b358d0d85",
+                "reference": "2afb87b740cb5c8bbfb72a27dbbe271b358d0d85",
                 "shasum": ""
             },
             "require": {
@@ -4457,9 +4457,9 @@
             "support": {
                 "docs": "https://github.com/statikbe/craft-video-parser/blob/master/README.md",
                 "issues": "https://github.com/statikbe/craft-video-parser/issues",
-                "source": "https://github.com/statikbe/craft-video-parser/tree/2.1.0"
+                "source": "https://github.com/statikbe/craft-video-parser/tree/2.1.1"
             },
-            "time": "2022-07-27T15:47:53+00:00"
+            "time": "2023-09-15T13:37:01+00:00"
         },
         {
             "name": "stripe/stripe-php",
@@ -7655,5 +7655,5 @@
         "ext-json": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/templates/_site/_snippet/_content/_blocks/_textVideo.twig
+++ b/templates/_site/_snippet/_content/_blocks/_textVideo.twig
@@ -7,7 +7,7 @@
             {% set embed = craft.videoparser.parse(block.video) %}
             {% if embed %}
                 <div class="embed-container">
-                    <iframe type="text/html" src="{{ embed.embedSrc }}?iv_load_policy=3&rel=0" frameborder="0"
+                    <iframe type="text/html" src="{{ embed.embedSrc }}?{{ embed.extraParts ? embed.extraParts ~ '&' : '' }}iv_load_policy=3&rel=0" frameborder="0"
                             title="Embedded video" allowfullscreen></iframe>
                 </div>
             {% endif %}

--- a/templates/_site/_snippet/_content/_blocks/_video.twig
+++ b/templates/_site/_snippet/_content/_blocks/_video.twig
@@ -4,7 +4,7 @@
 
         {% if embed %}
             <div class="embed-container">
-                <iframe type="text/html" src="{{ embed.embedSrc }}?iv_load_policy=3&rel=0" frameborder="0"
+                <iframe type="text/html" src="{{ embed.embedSrc }}?{{ embed.extraParts ? embed.extraParts ~ '&' : '' }}iv_load_policy=3&rel=0" frameborder="0"
                         title="Embedded video" allowfullscreen></iframe>
             </div>
         {% endif %}


### PR DESCRIPTION
In watwec wou de klant vimeo video's gebruiken die aan hun organisation account hangen. Daardoor krijgen die een ander soort URL dat de video-parser niet kon parsen. 

Deze nieuwe urls kopieren zij uit de backend als 'https://vimeo.com/834728934/3fb1f201e9' en om te embedden moeten dit worden 'https://player.vimeo.com/video/834728934?h=3fb1f201e9' 

Deze pull request voegt aan de base install toe dat wij out of the box al deze video format supporten. 