### PR TITLE
Remove asset usage plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
   "require": {
     "php": ">=8.1",
     "ext-json": "*",
-    "born05/craft-assetusage": "3.2.0",
     "craftcms/ckeditor": "3.4.0",
     "craftcms/cms": "4.5.3",
     "craftcms/postmark": "3.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,57 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "12322d0e6f0920e2d0c29fa6739d7450",
+    "content-hash": "416f4eefd2ec8aa41962e258a075edbe",
     "packages": [
-        {
-            "name": "born05/craft-assetusage",
-            "version": "3.2.0",
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/born05/craft-assetusage/zipball/c4efd889714825ae2be8ce9738bc46f679c9eee1",
-                "reference": "c4efd889714825ae2be8ce9738bc46f679c9eee1",
-                "shasum": ""
-            },
-            "require": {
-                "craftcms/cms": "^4.0.0-beta.1",
-                "php": "^8.0.2"
-            },
-            "type": "craft-plugin",
-            "extra": {
-                "name": "Asset Usage",
-                "handle": "assetusage",
-                "hasCpSettings": false,
-                "hasCpSection": false,
-                "changelogUrl": "https://raw.githubusercontent.com/born05/craft-assetusage/craft4/CHANGELOG.md"
-            },
-            "autoload": {
-                "psr-4": {
-                    "born05\\assetusage\\": "src/"
-                }
-            },
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Born05",
-                    "homepage": "https://www.born05.com/"
-                }
-            ],
-            "description": "Adds a column to see which assets are used or unused.",
-            "keywords": [
-                "asset usage",
-                "cms",
-                "craft",
-                "craft-plugin",
-                "craftcms"
-            ],
-            "support": {
-                "docs": "https://github.com/born05/craft-assetusage/blob/craft4/README.md",
-                "issues": "https://github.com/born05/craft-assetusage/issues"
-            },
-            "time": "2023-06-20T14:21:01+00:00"
-        },
         {
             "name": "cebe/markdown",
             "version": "1.2.1",

--- a/config/project/project.yaml
+++ b/config/project/project.yaml
@@ -364,10 +364,6 @@ meta:
     fca40313-aa0d-4206-a530-c638a5166f69: 'Background Color' # Background Color
     fd2014b7-5bc0-49a9-ac30-e009081532f7: FR # FR
 plugins:
-  assetusage:
-    edition: standard
-    enabled: true
-    schemaVersion: 2.0.0
   ckeditor:
     edition: standard
     enabled: true


### PR DESCRIPTION
It currently shows incorrect results a lot of the time, which leads to clients removing images that were still being used.