### PR TITLE
More robust check if we can show edit pencil

### DIFF
--- a/templates/_site/_layout.twig
+++ b/templates/_site/_layout.twig
@@ -36,7 +36,7 @@
 			{% set systemOffline = false %}
 		{% endif %}
 
-		{% if currentUser and entry is defined and not systemOffline and not craft.app.request.isPreview() %}
+		{% if currentUser and entry is defined and entry.canSave(entry) and not systemOffline and not craft.app.request.isPreview() %}
 			<a href="{{ entry.getCpEditUrl() }}" target="_blank" class="hidden md:inline-block transform translate-x-[115px] fixed px-4 py-2 text-white bg-primary right-0 rounded-l-full shadow-lg top-10 z-99 transition ease duration-400 hover:translate-x-0">
 				<span>{{ svg('@webroot/frontend/icons/pencil.svg')|attr({class: 'icon -mt-1'}) }}</span>
 				<span class="ml-2">Edit this page</span>


### PR DESCRIPTION
Add entry.canSave(currentUser) check to edit pencil to avoid showing it when the page is not available to edit for currentUser