### PR TITLE
[DEPLOY] Fix broken deploy when deploying content migration that needs new project config to be applied 

### DIFF
--- a/post-deploy-craft3.sh
+++ b/post-deploy-craft3.sh
@@ -55,8 +55,7 @@ executeCommand() {
 
 executeCommand "composer install --no-dev" "Installing composer requirements..."
 executeCommand "chmod +x ./craft"
-executeCommand "./craft migrate/all"
-executeCommand "./craft project-config/apply"
+executeCommand "./craft up"
 executeCommand "./craft clear-caches/all"
 
 FILE="config/htaccess-$ENVIRONMENT"


### PR DESCRIPTION

The correct order of deploying [which using craft up guarantees] is that 
- craft and plugin migrations get applied
- new project config gets applied
- content migrations are run. 

However on the old setup we forced all migrations craft + plugins + content to be run before the project config gets applied. This breaks any content  migration that relies on new fields to be present.  