### PR TITLE
Fix: Sync PHP version

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,4 +1,4 @@
-image: statikbe/bitbucket-php81:latest
+image: statikbe/bitbucket-php82:latest
 
 pipelines:
   branches:

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   ],
   "type": "project",
   "require": {
-    "php": ">=8.1",
+    "php": ">=8.2",
     "ext-json": "*",
     "craftcms/ckeditor": "3.4.0",
     "craftcms/cms": "4.5.11.1",


### PR DESCRIPTION
### Description

Sync PHP version to match default DDEV configuration so deploy and combell server setting work out of box

### Reason for this change

If  you start a new project right now because of the the DDEV configuration the minimum requirement of PHP packages will be PHP 8.2. By setting the minimum PHP requirement in bitbucket container and composer deploying will work right out of the box. 