### PR TITLE
ECS checks on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: ci
+on:
+  workflow_dispatch:
+  push:
+    branches: [ develop ]
+  pull_request:
+permissions:
+  contents: read
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  ci:
+    name: ci
+    uses: statikbe/.github/.github/workflows/ci.yml@main
+    with:
+      craft_version: '4'
+      jobs: '["ecs"]'
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,5 +16,6 @@ jobs:
     with:
       craft_version: '4'
       jobs: '["ecs"]'
+      php_version: '8.2'
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/modules/statik/src/Statik.php
+++ b/modules/statik/src/Statik.php
@@ -21,10 +21,10 @@ use modules\statik\services\LanguageService;
 use modules\statik\variables\StatikVariable;
 use modules\statik\web\twig\HyperExtension;
 use modules\statik\web\twig\HyphenateExtension;
-use modules\statik\web\twig\PaginateExtension;
-use modules\statik\web\twig\ValidateInputExtension;
-use modules\statik\web\twig\StatikExtension;
 use modules\statik\web\twig\IconExtension;
+use modules\statik\web\twig\PaginateExtension;
+use modules\statik\web\twig\StatikExtension;
+use modules\statik\web\twig\ValidateInputExtension;
 use verbb\formie\events\RegisterFieldsEvent;
 use verbb\formie\fields\formfields;
 use yii\base\Event;
@@ -71,7 +71,7 @@ class Statik extends Module
         }
 
         // Base template directory
-        Event::on(View::class, View::EVENT_REGISTER_CP_TEMPLATE_ROOTS, function (RegisterTemplateRootsEvent $e) {
+        Event::on(View::class, View::EVENT_REGISTER_CP_TEMPLATE_ROOTS, function(RegisterTemplateRootsEvent $e) {
             if (is_dir($baseDir = $this->getBasePath() . DIRECTORY_SEPARATOR . 'templates')) {
                 $e->roots[$this->id] = $baseDir;
             }
@@ -97,7 +97,7 @@ class Statik extends Module
         }
 
         // Register our variables
-        Event::on(CraftVariable::class, CraftVariable::EVENT_INIT, function (Event $event) {
+        Event::on(CraftVariable::class, CraftVariable::EVENT_INIT, function(Event $event) {
             /** @var CraftVariable $variable */
             $variable = $event->sender;
             $variable->set('statik', StatikVariable::class);
@@ -111,22 +111,22 @@ class Statik extends Module
         Craft::$app->view->registerTwigExtension(new StatikExtension());
         Craft::$app->view->registerTwigExtension(new PaginateExtension());
 
-        Event::on(Assets::class, Assets::EVENT_SET_FILENAME, function (SetAssetFilenameEvent $event) {
+        Event::on(Assets::class, Assets::EVENT_SET_FILENAME, function(SetAssetFilenameEvent $event) {
             $event->extension = mb_strtolower($event->extension);
         });
 
         if (Craft::$app->getRequest()->getIsCpRequest()) {
-            Event::on(View::class, View::EVENT_BEFORE_RENDER_TEMPLATE, function (TemplateEvent $event) {
+            Event::on(View::class, View::EVENT_BEFORE_RENDER_TEMPLATE, function(TemplateEvent $event) {
                 Craft::$app->getView()->registerAssetBundle(StatikAsset::class);
             });
         }
 
         // Register our fields
-        Event::on(Fields::class, Fields::EVENT_REGISTER_FIELD_TYPES, function (RegisterComponentTypesEvent $event) {
+        Event::on(Fields::class, Fields::EVENT_REGISTER_FIELD_TYPES, function(RegisterComponentTypesEvent $event) {
             $event->types[] = AnchorLink::class;
         });
 
-        Event::on(\verbb\formie\services\Fields::class, \verbb\formie\services\Fields::EVENT_REGISTER_FIELDS, function (RegisterFieldsEvent $event) {
+        Event::on(\verbb\formie\services\Fields::class, \verbb\formie\services\Fields::EVENT_REGISTER_FIELDS, function(RegisterFieldsEvent $event) {
             $excludedFields = [
                 formfields\Address::class,
                 formfields\Group::class,
@@ -146,7 +146,7 @@ class Statik extends Module
             $event->fields = array_values($event->fields);
         });
 
-        Event::on(Cp::class, Cp::EVENT_REGISTER_CP_NAV_ITEMS, function (RegisterCpNavItemsEvent $event) {
+        Event::on(Cp::class, Cp::EVENT_REGISTER_CP_NAV_ITEMS, function(RegisterCpNavItemsEvent $event) {
             if (Craft::$app->getConfig()->getGeneral()->allowAdminChanges) {
                 $event->navItems[] = [
                     'url' => 'settings/fields',

--- a/modules/statik/src/console/controllers/SetupController.php
+++ b/modules/statik/src/console/controllers/SetupController.php
@@ -82,7 +82,7 @@ EOD;
             // Replace self::PROJECT_CODE_PLACEHOLDER in htaccess-staging and htaccess-production
             $this->replaceInFile(Craft::$app->path->getConfigPath() . '/htaccess-staging', $newProjectCode);
             $this->replaceInFile(Craft::$app->path->getConfigPath() . '/htaccess-production', $newProjectCode);
-            foreach(self::DEPLOY_FILES as $deployFile) {
+            foreach (self::DEPLOY_FILES as $deployFile) {
                 $this->replaceInFile($deployFile, $newProjectCode);
             }
         }

--- a/modules/statik/src/web/twig/HyperExtension.php
+++ b/modules/statik/src/web/twig/HyperExtension.php
@@ -3,9 +3,9 @@
 namespace modules\statik\web\twig;
 
 use Craft;
+use craft\web\View;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
-use craft\web\View;
 use verbb\hyper\models\LinkCollection;
 
 class HyperExtension extends AbstractExtension
@@ -44,5 +44,4 @@ class HyperExtension extends AbstractExtension
 
         return $html;
     }
-
 }

--- a/modules/statik/src/web/twig/HyphenateExtension.php
+++ b/modules/statik/src/web/twig/HyphenateExtension.php
@@ -4,7 +4,6 @@ namespace modules\statik\web\twig;
 
 use Craft;
 use craft\elements\Asset;
-use craft\helpers\ElementHelper;
 use Twig\Extension\AbstractExtension;
 use Twig\Markup;
 use Twig\TwigFilter;
@@ -25,7 +24,7 @@ class HyphenateExtension extends AbstractExtension
 
         $output = Craft::$app->getCache()->getOrSet(
             "hypen-" . base64_encode($source),
-            function () use ($source, $minimumWordLength) {
+            function() use ($source, $minimumWordLength) {
                 $source = preg_replace('/&(?!amp)/', '&amp;', $source);
                 $language = strtolower(explode('-', Craft::$app->language)[0]);
                 $language = $language === 'en' ? 'en-us' : $language;

--- a/modules/statik/src/web/twig/PaginateExtension.php
+++ b/modules/statik/src/web/twig/PaginateExtension.php
@@ -3,10 +3,10 @@
 namespace modules\statik\web\twig;
 
 use Craft;
+use craft\web\twig\variables\Paginate;
+use craft\web\View;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
-use craft\web\View;
-use craft\web\twig\variables\Paginate;
 
 class PaginateExtension extends AbstractExtension
 {
@@ -36,5 +36,4 @@ class PaginateExtension extends AbstractExtension
             'options' => $options,
         ], View::TEMPLATE_MODE_SITE);
     }
-
 }

--- a/modules/statik/src/web/twig/StatikExtension.php
+++ b/modules/statik/src/web/twig/StatikExtension.php
@@ -2,13 +2,13 @@
 
 namespace modules\statik\web\twig;
 
+use craft\elements\Entry;
+use craft\helpers\ElementHelper;
 use Jaybizzle\CrawlerDetect\CrawlerDetect;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\GlobalsInterface;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
-use craft\elements\Entry;
-use craft\helpers\ElementHelper;
 
 class StatikExtension extends AbstractExtension implements GlobalsInterface
 {

--- a/modules/statik/src/web/twig/ValidateInputExtension.php
+++ b/modules/statik/src/web/twig/ValidateInputExtension.php
@@ -26,11 +26,11 @@ class ValidateInputExtension extends AbstractExtension
             return false;
         }
 
-        if(!is_array($input)) {
+        if (!is_array($input)) {
             return is_numeric($input);
         }
 
-        foreach($input as $value) {
+        foreach ($input as $value) {
             if (!$this->validateIdInput($value)) {
                 return false;
             }
@@ -50,7 +50,7 @@ class ValidateInputExtension extends AbstractExtension
             return preg_match(self::COMMON_QUERY_CHARACTERS_REGEX, $input);
         }
 
-        foreach($input as $value) {
+        foreach ($input as $value) {
             if (!$this->validateQueryInput($value)) {
                 return false;
             }
@@ -58,5 +58,4 @@ class ValidateInputExtension extends AbstractExtension
 
         return true;
     }
-
 }


### PR DESCRIPTION
This PR adds an automatic code styling check that will run for any new PR, to ensure that our code all follows the same style & conventions.

The check is defined for our organisation (https://github.com/statikbe/.github/tree/main/.github/workflows), so we can easily expand and update these checks outside of the repository.

You can run these check locally as well, with the command `(ddev) composer check-cs` to just check your code, or `(ddev) composer fix-cs` to have any errors fixed automatically.