### PR TITLE
322: fixed regex in the validateInputExtension file

### DIFF
--- a/modules/statik/src/web/twig/ValidateInputExtension.php
+++ b/modules/statik/src/web/twig/ValidateInputExtension.php
@@ -9,7 +9,7 @@ use function is_numeric;
 
 class ValidateInputExtension extends AbstractExtension
 {
-    private const COMMON_QUERY_CHARACTERS_REGEX = "/^[a-zA-Z0-9.!?'\"]+$/";
+    private const COMMON_QUERY_CHARACTERS_REGEX = "/^[a-zA-Z0-9.!?\s'\"]+$/";
 
     public function getTests(): array
     {


### PR DESCRIPTION
Fix issue: https://github.com/statikbe/craft/issues/322

Updated regex to allow spaces in a search term.