### PR TITLE
Added frontend build to bitbucket pipeline for faster building

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -11,6 +11,7 @@ pipelines:
           script:
             # build frontend and run composer
             - composer install --verbose --prefer-dist --no-progress --no-interaction --no-dev --optimize-autoloader
+            - sh ./bitbucket_pipelines_build_frontend.sh
             # deploy:
             - cp .deploy/ssh/* ~/.ssh/. && chmod 400 ~/.ssh/bitbucket_pipelines*
             - dep deploy staging -vv

--- a/bitbucket_pipelines_build_frontend.sh
+++ b/bitbucket_pipelines_build_frontend.sh
@@ -1,0 +1,9 @@
+#!bin/bash
+
+# curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+nvm install && nvm use
+npm install -g yarn
+yarn install
+yarn prod

--- a/deploy.php
+++ b/deploy.php
@@ -100,11 +100,6 @@ task('craft:clear_caches', function () {
     run('{{release_path}}/craft clear-caches/all');
 })->once();
 
-desc('Frontend build');
-task('statik:frontend_build', function () {
-    run('cd {{release_path}} && yarn install && yarn run prod');
-})->once();
-
 desc('Fichenbak versioning');
 task('statik:fichenbak_versioning', function () {
     run('if [ -s {{release_path}}/fichenbak-versioning.sh ]; then sh {{release_path}}/fichenbak-versioning.sh; fi');
@@ -161,7 +156,6 @@ task('deploy', [
     'craft:clear_caches',
     'statik:copy_htaccess',
     'statik:copy_robots',
-    'statik:frontend_build',
     'statik:fichenbak_versioning',
     'deploy:publish',
 ]);


### PR DESCRIPTION
### Description

Removed frontend build from deploy.php script and added it to the bitbucket pipeline.

### Reason for this change

Bitbucket will cache the node_modules folder for next deployments. So it will be much quicker.
This will also decrease the build minutes in the pipeline.