### PR TITLE
[BUG]: anchor field does not work with question mark

### DIFF
--- a/modules/statik/src/assetbundles/anchorlinkfield/dist/js/AnchorLink.js
+++ b/modules/statik/src/assetbundles/anchorlinkfield/dist/js/AnchorLink.js
@@ -93,7 +93,7 @@
         // ajax to php function
         $.ajax({
             url: "/actions/statik/slugify/create-slug-from-string",
-            data: {string: string},
+            data: {string: encodeURIComponent(string)},
             async: false,
         }).done(function (response) {
             $slugified = response;

--- a/modules/statik/src/controllers/SlugifyController.php
+++ b/modules/statik/src/controllers/SlugifyController.php
@@ -12,7 +12,7 @@ class SlugifyController extends Controller
 
     public function actionCreateSlugFromString(): string
     {
-        $string = Craft::$app->request->getParam('string');
+        $string = urldecode(Craft::$app->request->getParam('string'));
         return ElementHelper::generateSlug($string);
     }
 }


### PR DESCRIPTION
### Description

If uri part didn't get explicitely encoded browsers would struggle with the ? part. 

### Reason for this change

fixes #421 