### PR TITLE
[CONFIG] #422 add recaptcha default on forms

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,10 @@ SYSTEM_NAME="Craft"
 # postmarkapp.com API key
 POSTMARK_API_KEY=""
 
+# Recaptcha
+RECAPTCHA_SITE_KEY=""
+RECAPTCHA_SECRET_KEY=""
+
 # Address to which Craft's testToEmailAddress will be site
 DEBUG_EMAIL=""
 

--- a/config/project/formie/stencils/contactForm_EN--ac589bc4-75c7-4f97-b57b-61025fc0643f.yaml
+++ b/config/project/formie/stencils/contactForm_EN--ac589bc4-75c7-4f97-b57b-61025fc0643f.yaml
@@ -395,6 +395,9 @@ data:
       javascript:
         enabled: '1'
         showAllPages: '1'
+      recaptcha:
+        enabled: '1'
+        showAllPages: ''
     limitSubmissions: false
     limitSubmissionsMessage: '[{"type":"paragraph","attrs":{"textAlign":"start"}}]'
     limitSubmissionsNumber: null

--- a/config/project/formie/stencils/contactForm_FR--68c6a8e9-4391-473a-8b44-293bb38d1f32.yaml
+++ b/config/project/formie/stencils/contactForm_FR--68c6a8e9-4391-473a-8b44-293bb38d1f32.yaml
@@ -395,6 +395,9 @@ data:
       javascript:
         enabled: '1'
         showAllPages: '1'
+      recaptcha:
+        enabled: '1'
+        showAllPages: ''
     limitSubmissions: false
     limitSubmissionsMessage: '[{"type":"paragraph","attrs":{"textAlign":"start"}}]'
     limitSubmissionsNumber: null

--- a/config/project/formie/stencils/contactForm_NL--b1ca80f0-4eed-4f99-bebc-bca6c694cb00.yaml
+++ b/config/project/formie/stencils/contactForm_NL--b1ca80f0-4eed-4f99-bebc-bca6c694cb00.yaml
@@ -399,6 +399,9 @@ data:
       javascript:
         enabled: '1'
         showAllPages: '1'
+      recaptcha:
+        enabled: '1'
+        showAllPages: ''
     limitSubmissions: false
     limitSubmissionsMessage: '[{"type":"paragraph","attrs":{"textAlign":"start"}}]'
     limitSubmissionsNumber: null

--- a/config/project/project.yaml
+++ b/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1739370540
+dateModified: 1739372611
 elementSources:
   craft\elements\Entry:
     -
@@ -428,7 +428,7 @@ plugins:
     licenseKey: WLZ7JMGY8H2EIESZYMEZ3EPW
     schemaVersion: 3.4.8
     settings:
-      ajaxTimeout: '10'
+      ajaxTimeout: 10
       alertEmails: null
       captchas:
         __assoc__:
@@ -441,7 +441,10 @@ plugins:
                   - verbb\formie\integrations\captchas\Recaptcha
                 -
                   - enabled
-                  - false
+                  - '1'
+                -
+                  - saveSpam
+                  - true
                 -
                   - settings
                   -
@@ -451,10 +454,10 @@ plugins:
                         - recaptcha
                       -
                         - secretKey
-                        - ''
+                        - $RECAPTCHA_SECRET_KEY
                       -
                         - siteKey
-                        - ''
+                        - $RECAPTCHA_SITE_KEY
                       -
                         - type
                         - v3
@@ -466,16 +469,19 @@ plugins:
                         - light
                       -
                         - badge
-                        - bottomright
+                        - inline
                       -
                         - language
                         - en
                       -
                         - minScore
-                        - '0.5'
+                        - 0.5
                       -
-                        - projectId
-                        - ''
+                        - scriptLoadingMethod
+                        - asyncDefer
+                      -
+                        - enterpriseType
+                        - score
           -
             - hcaptcha
             -
@@ -485,32 +491,32 @@ plugins:
                   - verbb\formie\integrations\captchas\Hcaptcha
                 -
                   - enabled
-                  - false
+                  - '0'
+                -
+                  - saveSpam
+                  - true
                 -
                   - settings
                   -
                     __assoc__:
-                      -
+                      0:
                         - handle
                         - hcaptcha
-                      -
-                        - secretKey
-                        - ''
-                      -
-                        - siteKey
-                        - ''
-                      -
+                      3:
                         - size
                         - normal
-                      -
+                      4:
                         - theme
                         - light
-                      -
+                      5:
                         - language
                         - en
-                      -
+                      6:
                         - minScore
-                        - '0.5'
+                        - 0.5
+                      7:
+                        - scriptLoadingMethod
+                        - asyncDefer
           -
             - duplicate
             -
@@ -520,7 +526,10 @@ plugins:
                   - verbb\formie\integrations\captchas\Duplicate
                 -
                   - enabled
-                  - false
+                  - '0'
+                -
+                  - saveSpam
+                  - true
                 -
                   - settings
                   -
@@ -537,6 +546,9 @@ plugins:
                   - verbb\formie\integrations\captchas\Honeypot
                 -
                   - enabled
+                  - '1'
+                -
+                  - saveSpam
                   - true
                 -
                   - settings
@@ -554,6 +566,9 @@ plugins:
                   - verbb\formie\integrations\captchas\Javascript
                 -
                   - enabled
+                  - '1'
+                -
+                  - saveSpam
                   - true
                 -
                   - settings
@@ -562,9 +577,64 @@ plugins:
                       -
                         - handle
                         - javascript
-                      -
-                        - minTime
-                        - ''
+          -
+            - friendlyCaptcha
+            -
+              __assoc__:
+                -
+                  - type
+                  - verbb\formie\integrations\captchas\FriendlyCaptcha
+                -
+                  - enabled
+                  - '0'
+                -
+                  - saveSpam
+                  - true
+                -
+                  - settings
+                  -
+                    __assoc__:
+                      0:
+                        - handle
+                        - friendlyCaptcha
+                      3:
+                        - language
+                        - en
+                      4:
+                        - startMode
+                        - none
+          -
+            - turnstile
+            -
+              __assoc__:
+                -
+                  - type
+                  - verbb\formie\integrations\captchas\Turnstile
+                -
+                  - enabled
+                  - '0'
+                -
+                  - saveSpam
+                  - true
+                -
+                  - settings
+                  -
+                    __assoc__:
+                      0:
+                        - handle
+                        - turnstile
+                      3:
+                        - scriptLoadingMethod
+                        - asyncDefer
+                      4:
+                        - theme
+                        - auto
+                      5:
+                        - size
+                        - normal
+                      6:
+                        - appearance
+                        - always
       defaultDateDisplayType: ''
       defaultDateTime: null
       defaultDateValueOption: ''
@@ -574,24 +644,34 @@ plugins:
       defaultInstructionsPosition: verbb\formie\positions\AboveInput
       defaultLabelPosition: verbb\formie\positions\AboveInput
       defaultPage: forms
-      enableCsrfValidationForGuests: '1'
-      enableGatsbyCompatibility: false
-      enableUnloadWarning: '1'
-      maxIncompleteSubmissionAge: '30'
+      emptyValuePlaceholder: 'No response.'
+      enableBackSubmission: true
+      enableCsrfValidationForGuests: true
+      enableLargeFieldStorage: false
+      enableUnloadWarning: true
+      filterIntegrationMapping: true
+      includeDraftElementUsage: false
+      includeRevisionElementUsage: false
+      maxIncompleteSubmissionAge: 30
       maxSentNotificationsAge: 30
       pdfPaperOrientation: portrait
       pdfPaperSize: letter
       pluginName: Formie
+      queuePriority: null
       saveSpam: true
       sendEmailAlerts: false
       sentNotifications: true
+      setOnlyCurrentPagePayload: false
       spamBehaviour: showSuccess
       spamBehaviourMessage: ''
       spamEmailNotifications: false
       spamKeywords: ''
       spamLimit: 500
-      useQueueForIntegrations: ''
-      useQueueForNotifications: ''
+      submissionsBehaviour: all
+      useCssLayers: false
+      useQueueForIntegrations: false
+      useQueueForNotifications: false
+      validateCustomTemplates: true
   hyper:
     edition: standard
     enabled: true

--- a/modules/statik/src/console/controllers/SetupController.php
+++ b/modules/statik/src/console/controllers/SetupController.php
@@ -56,6 +56,7 @@ EOD;
         $this->setProjectCode();
         $this->removeAccountFlow();
         $this->setPostmarkKey();
+        $this->setRecaptchaKey();
         $this->setupGit();
 
         $this->stdout("All done! Happy coding!" . PHP_EOL, Console::FG_GREEN);
@@ -140,7 +141,7 @@ EOD;
     }
 
     /**
-     * Prompts the user if Mandrill should be used for e-mail transport and asks to enter an API key
+     * Prompts the user if Postmark should be used for e-mail transport and asks to enter an API key
      */
     private function setPostmarkKey(): void
     {
@@ -155,6 +156,31 @@ EOD;
                     if ($this->setEnvVar("DEBUG_EMAIL", $testEmail)) {
                         $this->stdout("Done!" . PHP_EOL, Console::FG_GREEN);
                     }
+                }
+            } else {
+                $this->stdout("Key not found, aborting" . PHP_EOL, Console::FG_RED);
+            }
+        }
+    }
+
+    /**
+     * Prompts the user if recaptcha will be used and asks to enter an API key
+     */
+    private function setRecaptchaKey(): void
+    {
+        if ($this->confirm("Do you want to use Recaptcha for spam protection?", true)) {
+            $key = $this->prompt("> Enter a recaptcha SITE key:");
+            if ($key) {
+                if ($this->setEnvVar("RECAPTCHA_SITE_KEY", $key)) {
+                    $this->stdout("Done!" . PHP_EOL, Console::FG_GREEN);
+                }
+            } else {
+                $this->stdout("Key not found, aborting" . PHP_EOL, Console::FG_RED);
+            }
+            $key = $this->prompt("> Enter a recaptcha SECRET key:");
+            if ($key) {
+                if ($this->setEnvVar("RECAPTCHA_SECRET_KEY", $key)) {
+                    $this->stdout("Done!" . PHP_EOL, Console::FG_GREEN);
                 }
             } else {
                 $this->stdout("Key not found, aborting" . PHP_EOL, Console::FG_RED);


### PR DESCRIPTION
### Description
Set recaptcha on by default in formie settings and stencils.
Setup command now asks for recaptcha key on initial setup to add it to the .env file. 

### Reason for this change

We want to help developers make sane defaults