### PR TITLE
[Feature] Allow disabling the backend for a content freeze. 

### DIFF
--- a/config/custom.php
+++ b/config/custom.php
@@ -3,6 +3,7 @@
 return [
     // Custom settings
     '*' => [
+        'maintenanceMode' => false,
         'cse' => [
             'nl' => 'test-nl',
             'fr' => 'test-fr',


### PR DESCRIPTION
Handy for migrations. All admins on the backend when the freeze is enforced will be automatically logged out. 

When people try to log in while maintenance mode is on they receive the following message.

![Screenshot 2025-05-26 at 10 28 03](https://github.com/user-attachments/assets/bf94141c-9c4c-498a-a948-0980b80a36d5)
