### PR TITLE
[SEO] Added robots-denied.txt to always block *.statik.be domains

### DIFF
--- a/public/robots-denied.txt
+++ b/public/robots-denied.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
In htaccess hebben we volgende regel staan voor staging & productie:

````
  # Set a seperate robots to all .statik domains
  RewriteCond %{HTTP_HOST} ^(^.*)\.statik.be$
  RewriteRule ^robots\.txt$ robots-denied.txt [L]
````

Dat zou er voor moeten zorgen dat elke url me ".statik.be" een aparte robots krijgt, om indexering te voorkomen.
Alleen bestaat die aparte robots niet meer. Ik heb niet uitgezocht hoe dat komt of sinds wanneer het stuk is, maar dit voegt het in ieder geval terug toe.

