### PR TITLE
[BUG] node_modules folder not cached in deploys

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -30,3 +30,7 @@ pipelines:
             - sh ./bitbucket_pipelines_build_frontend.sh
             # Deploy to production
             - dep deploy production -vv
+
+definitions:
+  caches:
+    node: frontend/node_modules


### PR DESCRIPTION
### Description
This changes the definition for the node caching strategy to look for the folder node_modules in /frontend.

### Reason for this change
Because the frontend build was moved to the /frontend folder the node modules folder was no longer being cached.