### PR TITLE
Block youtube video's if cookies are not set

### DIFF
--- a/frontend/css/site/main.css
+++ b/frontend/css/site/main.css
@@ -40,7 +40,7 @@
 /* @source "../../js/components-core/modal.component.ts"; */
 /* @source "../../js/plugins/modal"; */
 /* @source "../../js/components-core/videoBackground.component.ts"; */
-/* @source "../../js/components-core/videoToggle.component.ts"; */
+@source "../../js/components-core/videoToggle.component.ts";
 /* @source "../../js/plugins/validation/passwordStrength.component.ts"; */
 
 @utility container {

--- a/frontend/js/components-core/videoToggle.component.ts
+++ b/frontend/js/components-core/videoToggle.component.ts
@@ -1,11 +1,30 @@
 import { DOMHelper } from '../utils/domHelper';
+import { Cookies } from '../utils/cookies';
 
 export default class VideoToggleComponent {
   constructor() {
-    const triggers = document.querySelectorAll('button[data-video-toggle]');
+    const triggers = document.querySelectorAll<HTMLButtonElement>('button[data-video-toggle]');
     Array.from(triggers).forEach((trigger, index) => {
       new VideoToggle(trigger as HTMLButtonElement, index);
     });
+
+    // Videos are blocked until cookie consent is given. The cookie banner dispatches a
+    // `cookie-closed` event whenever the visitor makes a choice, so re-enable the triggers
+    // and remove the consent blockers once an accepting choice comes in.
+    const consent = Cookies.getCookie('__cookie_consent');
+    if (consent !== 'true' && consent !== '3') {
+      window.addEventListener('cookie-closed', () => {
+        const newConsent = Cookies.getCookie('__cookie_consent');
+        if (newConsent === 'true' || newConsent === '3') {
+          triggers.forEach((trigger) => {
+            trigger.disabled = false;
+          });
+          document.querySelectorAll('[data-video-consent-blocker]').forEach((blocker) => {
+            blocker.remove();
+          });
+        }
+      });
+    }
   }
 }
 
@@ -29,7 +48,7 @@ class VideoToggle {
 
   private cssClasses = {
     videoToggleContainer: 'video-toggle__container relative',
-    videoToggleContent: 'video-toggle__content absolute top-0 right-0 bottom-0 left-0',
+    videoToggleContent: 'video-toggle__content absolute inset-0',
     videoToggleIframe: 'video-toggle__iframe',
     videoToggleClose: 'video-toggle__close absolute top-0 right-0 p-2 bg-white',
     videoToggleCloseAfter:

--- a/setup-translations/fr-BE/site.php
+++ b/setup-translations/fr-BE/site.php
@@ -75,4 +75,8 @@ return array(
         'Toon/verberg paswoord' => 'Affichez/masquez le mot de passe',
         'Are you sure you want to navigate to the Statik website?' => 'Êtes-vous sûr de vouloir accéder au site web de Statik ?',
         'Stop video' => 'Arrêtez la vidéo',
+        'Cookie consent required' => 'Consentement aux cookies requis',
+        'This video can only be viewed after accepting cookies' => 'Cette vidéo ne peut être visionnée qu\'après avoir accepté les cookies',
+        'Accept cookies' => 'Accepter les cookies',
+        'Or view this video on ' => 'Ou regardez cette vidéo sur ',
 );

--- a/setup-translations/nl-BE/site.php
+++ b/setup-translations/nl-BE/site.php
@@ -75,4 +75,8 @@ return array(
         'Bekijk meer nieuws' => 'Bekijk meer nieuws',
         'Are you sure you want to navigate to the Statik website?' => 'Ben je zeker dat je naar de Statik website wil surfen?',
         'Stop video' => 'Stop video',
+        'Cookie consent required' => 'Cookietoestemming vereist',
+        'This video can only be viewed after accepting cookies' => 'Deze video kan pas bekeken worden na het accepteren van cookies',
+        'Accept cookies' => 'Cookies accepteren',
+        'Or view this video on ' => 'Of bekijk deze video op ',
 );

--- a/templates/_site/_snippet/_content/_blocks/_textVideo.twig
+++ b/templates/_site/_snippet/_content/_blocks/_textVideo.twig
@@ -6,6 +6,7 @@
             {% if block.video|length %}
 
                 {% set embed = craft.videoparser.parse(block.video) %}
+                {% set consent = craft.app.request.rawCookies.value('__cookie_consent') %}
                 {% if embed %}
                     <figure class="block">
                         <div class="relative bg-center bg-cover bg-black/50 bg-blend-multiply aspect-video" data-bg-image id="video-{{block.id}}">
@@ -30,11 +31,22 @@
                             <button type="button" class="absolute inset-0"
                                     data-video-toggle="{{embed.embedSrc}}"
                                     data-video-toggle-container="#video-{{block.id}}"
-                                    data-video-toggle-show-close-button="false">
+                                    data-video-toggle-show-close-button="false"
+                                    {% if consent != "true" and consent != "3" %}disabled{% endif %}>
                                 <span class="absolute flex items-center px-4 py-2 text-white -translate-x-1/2 -translate-y-1/2 rounded bg-primary-dark top-1/2 left-1/2">
                                     {{ icon('play-arrow', { class: 'mr-2 text-xl' }) }}  {{ 'Play video'|t }}
                                 </span>
                             </button>
+                            {% if consent != "true" and consent != "3" %}
+                                <div class="absolute inset-0 z-10 flex flex-col items-center justify-center p-6 text-center bg-white/95" data-video-consent-blocker>
+                                    <h2 class="text-xl font-bold">{{ 'Cookie consent required'|t }}</h2>
+                                    <p class="mt-2">{{ 'This video can only be viewed after accepting cookies'|t }}</p>
+                                    <div class="flex flex-wrap items-center justify-center gap-2 mt-4 md:gap-6">
+                                        <button type="button" class="btn btn--primary js-cookie-settings">{{ 'Accept cookies'|t }}</button>
+                                        <a href="{{ block.video }}" class="underline hover:no-underline" target="_blank" rel="noopener">{{ "Or view this video on "|t }}{{ embed.type }}</a>
+                                    </div>
+                                </div>
+                            {% endif %}
                         </div>
                         {% if block.videoCaption|length %}
                             <figcaption class="mt-2 text-sm text-editor">

--- a/templates/_site/_snippet/_content/_blocks/_video.twig
+++ b/templates/_site/_snippet/_content/_blocks/_video.twig
@@ -1,6 +1,7 @@
 {% if block.video|length %}
     <figure class="block w-full mx-auto md:w-2/3">
         {% set embed = craft.videoparser.parse(block.video) %}
+        {% set consent = craft.app.request.rawCookies.value('__cookie_consent') %}
 
         {% if embed %}
             <div class="relative bg-center bg-cover aspect-video bg-black/50 bg-blend-multiply" data-bg-image id="video-{{block.id}}">
@@ -22,14 +23,25 @@
                         <img src="https://vumbnail.com/{{embed.id}}.jpg" alt="" class="js-bg-src"/>
                     {% endif %}
                 {% endif %}
-                <button type="button" class="absolute inset-0" 
-                            data-video-toggle="{{embed.embedSrc}}" 
+                <button type="button" class="absolute inset-0"
+                            data-video-toggle="{{embed.embedSrc}}"
                             data-video-toggle-container="#video-{{block.id}}"
-                            data-video-toggle-show-close-button="false">
+                            data-video-toggle-show-close-button="false"
+                            {% if consent != "true" and consent != "3" %}disabled{% endif %}>
                     <span class="absolute flex items-center px-4 py-2 text-white -translate-x-1/2 -translate-y-1/2 rounded bg-primary-dark top-1/2 left-1/2">
                         {{ icon('play-arrow', { class: 'mr-2 text-xl' }) }}  {{ 'Play video'|t }}
                     </span>
                 </button>
+                {% if consent != "true" and consent != "3" %}
+                    <div class="absolute inset-0 z-10 flex flex-col items-center justify-center p-6 text-center bg-white/95" data-video-consent-blocker>
+                        <h2 class="text-xl font-bold">{{ 'Cookie consent required'|t }}</h2>
+                        <p class="mt-2">{{ 'This video can only be viewed after accepting cookies'|t }}</p>
+                        <div class="flex flex-wrap items-center justify-center gap-2 mt-4 sm:gap-6">
+                            <button type="button" class="btn btn--primary js-cookie-settings">{{ 'Accept cookies'|t }}</button>
+                            <a href="{{ block.video }}" class="underline hover:no-underline" target="_blank" rel="noopener">{{ "Or view this video on "|t }}{{ embed.type }}</a>
+                        </div>
+                    </div>
+                {% endif %}
             </div>
         {% endif %}
 


### PR DESCRIPTION
### Description
This PR is a first attempt at not loading youtube embeds when the user doesn't accepted marketing cookies.
- translations for the messages are added to the initial translation files
- we do load the thumbnail - that doesn't set cookies and otherwise the expierence is kind of meh.

