### PR TITLE
Feature/617 641 647 fix cache issues

### DIFF
--- a/config/craft-sentry.php
+++ b/config/craft-sentry.php
@@ -9,10 +9,10 @@ return [
     'excludedExceptions' => [
         \craft\errors\ImageTransformException::class,
         \yii\web\ForbiddenHttpException::class,
-        \craft\errors\AssetDisallowedExtensionException,
-        \craft\errors\FsObjectNotFoundException,
-        \Imagine\Exception\RuntimeException,
-        \craft\errors\ImageException,
+        \craft\errors\AssetDisallowedExtensionException::class,
+        \craft\errors\FsObjectNotFoundException::class,
+        \Imagine\Exception\RuntimeException::class,
+        \craft\errors\ImageException::class,
     ],
     'release'       => getenv('SENTRY_RELEASE') ?: null,
 ];

--- a/modules/statik/src/Statik.php
+++ b/modules/statik/src/Statik.php
@@ -4,6 +4,7 @@ namespace modules\statik;
 
 use Craft;
 use craft\console\Application as ConsoleApplication;
+use craft\elements\Entry;
 use craft\elements\User;
 use craft\events\RegisterComponentTypesEvent;
 use craft\events\RegisterCpNavItemsEvent;
@@ -204,6 +205,18 @@ class Statik extends Module
 
         Event::on(Links::class, Links::EVENT_REGISTER_LINK_TYPES, function(RegisterComponentTypesEvent $event) {
             $event->types[] = Anchor::class;
+        });
+
+        // clear cache after save for our global site settings
+        // TODO: if we have other global sections add them to clear their cache after save.
+        Event::on(Entry::class, Entry::EVENT_AFTER_SAVE, function (Event $event) {
+            /** @var Entry $entry */
+            $entry = $event->sender;
+            if($entry->getSection() !== null){
+                if ($entry->getSection()->handle === 'siteSettings') {
+                    Craft::$app->getCache()->delete('layout-fallback-' . $entry->siteId);
+                }
+            }
         });
 
         Event::on(Cp::class, Cp::EVENT_REGISTER_CP_NAV_ITEMS, function (RegisterCpNavItemsEvent $event) {

--- a/templates/_site/_contentPage.twig
+++ b/templates/_site/_contentPage.twig
@@ -3,7 +3,7 @@
 {% set breadcrumbs = entry.ancestors().all()|merge([entry]) %}
 
 {% block content %}
-{% cache globally unless currentUser or craft.app.request.isPreview() %}
+{% cache unless currentUser or craft.app.request.isPreview() %}
 
     {% include "_site/_snippet/_content/_defaultHeader" %}
 

--- a/templates/_site/_news/_entry.twig
+++ b/templates/_site/_news/_entry.twig
@@ -6,7 +6,7 @@
 ] %}
 
 {% block content %}
-{% cache globally unless currentUser or craft.app.request.isPreview() %}
+{% cache unless currentUser or craft.app.request.isPreview() %}
 
     {% embed "_site/_snippet/_content/_defaultHeader" %}
         {% block headerText %}


### PR DESCRIPTION
Fix issues: https://github.com/statikbe/craft/issues/617, https://github.com/statikbe/craft/issues/641 
By adding an after save event to bust the cache for global sections (site settings)

Fix: https://github.com/statikbe/craft/issues/647 
To remove global cache

Fix: add class issue sentry (related to merge https://github.com/statikbe/craft/pull/657)
