### PR TITLE
Build the Clint CLI on demand so yarn watch works on a fresh clone

### DIFF
--- a/clint/updates/20260902-build-the-clint-cli-on-demand-for-yarn-watch/CHANGELOG.md
+++ b/clint/updates/20260902-build-the-clint-cli-on-demand-for-yarn-watch/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Build the Clint CLI on demand for yarn watch
+
+**Release date:** 2026-09-02
+
+## Summary
+
+`yarn watch` failed on a fresh clone. The frontend scripts called `node ../clint/dist/cli.js` directly, but `clint/dist/` is a build artifact and is gitignored — so on a clone that had never built Clint, the command exited with `MODULE_NOT_FOUND` (exit code 1) and the `&& vite` never ran. The dev server simply refused to start, with a Node stack trace instead of a useful message.
+
+The frontend scripts now go through a small `frontend/ensure-clint.js` wrapper that builds the CLI once if it is missing, then runs the update check.
+
+## Added
+
+- `frontend/ensure-clint.js` — builds `clint/` (install + build) the first time it is needed, then forwards its arguments to the CLI.
+
+## Changed
+
+- `watch`: `node ../clint/dist/cli.js --checkupdates && vite` → `node ensure-clint.js --checkupdates && vite`
+- `dev`: `vite build && node  ../clint/dist/cli.js --checkupdates` → `vite build && node ensure-clint.js --checkupdates`
+
+## Fixed
+
+- **`yarn watch` and `yarn dev` work on a fresh clone**, with no manual Clint build step first.
+- **A broken or missing Clint no longer blocks the frontend.** The update check is now advisory: if Clint cannot be built or the check fails, you get a warning and Vite starts anyway. Previously any Clint problem stopped the dev server outright.
+- **`init-clint` and `update` pointed at a directory that does not exist.** Both ran `cd clint` from inside `frontend/`, resolving to `frontend/clint`. They now use `cd ../clint`, so `yarn init-clint` and `yarn update` work — `init-clint` in particular is what `yarn start` calls to build Clint in the first place.
+
+# Manual intervention
+
+> ⚠️ **ATTENTION**:
+> If your project has customised the `watch`, `dev`, `init-clint` or `update` scripts in
+> `frontend/package.json`, the automated replacements will not match and those scripts keep their
+> current form. Re-apply the change by hand: call `node ensure-clint.js` instead of
+> `node ../clint/dist/cli.js`, and make sure any `cd clint` is `cd ../clint`.
+>
+> The first `yarn watch` after this update builds the Clint CLI, so it takes a few seconds longer
+> than usual. Subsequent runs are unaffected.

--- a/clint/updates/20260902-build-the-clint-cli-on-demand-for-yarn-watch/update.json
+++ b/clint/updates/20260902-build-the-clint-cli-on-demand-for-yarn-watch/update.json
@@ -1,0 +1,33 @@
+{
+  "id": "20260902-build-the-clint-cli-on-demand-for-yarn-watch",
+  "title": "Build the Clint CLI on demand for yarn watch",
+  "description": "clint/dist is gitignored, so a fresh clone had no cli.js and `yarn watch` died before Vite started. The frontend scripts now go through ensure-clint.js, which builds the CLI once if it is missing and never blocks the dev server.",
+  "date": "2026-09-02",
+  "issues": [],
+  "pr": null,
+  "requires": [],
+  "frontend": {
+    "findAndReplace": [
+      {
+        "files": ["../frontend/package.json"],
+        "from": "\"watch\": \"node ../clint/dist/cli.js --checkupdates && vite\"",
+        "to": "\"watch\": \"node ensure-clint.js --checkupdates && vite\""
+      },
+      {
+        "files": ["../frontend/package.json"],
+        "from": "\"dev\": \"vite build && node  ../clint/dist/cli.js --checkupdates\"",
+        "to": "\"dev\": \"vite build && node ensure-clint.js --checkupdates\""
+      },
+      {
+        "files": ["../frontend/package.json"],
+        "from": "\"init-clint\": \"cd clint && yarn install && yarn run build\"",
+        "to": "\"init-clint\": \"cd ../clint && yarn install && yarn run build\""
+      },
+      {
+        "files": ["../frontend/package.json"],
+        "from": "\"update\": \"cd clint && yarn start\"",
+        "to": "\"update\": \"cd ../clint && yarn start\""
+      }
+    ]
+  }
+}

--- a/frontend/ensure-clint.js
+++ b/frontend/ensure-clint.js
@@ -1,0 +1,55 @@
+/**
+ * Runs the Clint CLI, building it first if it isn't there.
+ *
+ * `clint/dist/` is a build artifact and is gitignored, so a fresh clone has no `dist/cli.js`.
+ * The frontend scripts used to call `node ../clint/dist/cli.js` directly, which meant `yarn watch`
+ * died with MODULE_NOT_FOUND before Vite ever started. Building it on demand fixes that once.
+ *
+ * This never blocks the dev server: a missing or broken Clint is a warning, not a failure, so the
+ * update check can never stop you from working on the frontend. Usage:
+ *
+ *   node ensure-clint.js --checkupdates
+ */
+import { existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const clintDir = path.resolve(here, '..', 'clint');
+const cliPath = path.join(clintDir, 'dist', 'cli.js');
+
+// yarn resolves to yarn.cmd on Windows, which needs a shell to be spawnable.
+const useShell = process.platform === 'win32';
+
+function run(args, label) {
+  process.stdout.write(`⚙️  Clint: ${label} ...\n`);
+  const result = spawnSync('yarn', args, { cwd: clintDir, stdio: 'inherit', shell: useShell });
+  return result.status === 0;
+}
+
+function build() {
+  if (!existsSync(clintDir)) {
+    process.stdout.write(`⚠️  Clint: no ${clintDir} directory — skipping the update check.\n`);
+    return false;
+  }
+  process.stdout.write('⚙️  Clint: first run, building the CLI (this happens once) ...\n');
+
+  if (!existsSync(path.join(clintDir, 'node_modules')) && !run(['install'], 'installing dependencies')) {
+    return false;
+  }
+  // Full build: the CLI bundle plus the assets its changelog view renders from.
+  return run(['build'], 'building');
+}
+
+if (!existsSync(cliPath) && !build()) {
+  process.stdout.write('⚠️  Clint: could not build the CLI, skipping the update check.\n');
+  process.stdout.write('   Build it manually with: cd ../clint && yarn install && yarn build\n');
+  process.exit(0); // Never block the frontend build or dev server on this.
+}
+
+const result = spawnSync(process.execPath, [cliPath, ...process.argv.slice(2)], { stdio: 'inherit' });
+if (result.status !== 0) {
+  process.stdout.write('⚠️  Clint: the update check did not complete — continuing anyway.\n');
+}
+process.exit(0);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,9 +7,9 @@
         "test": "git change"
     },
     "scripts": {
-        "watch": "node ../clint/dist/cli.js --checkupdates && vite",
+        "watch": "node ensure-clint.js --checkupdates && vite",
         "watch-site2": "vite --config vite.config.site2.js",
-        "dev": "vite build && node  ../clint/dist/cli.js --checkupdates",
+        "dev": "vite build && node ensure-clint.js --checkupdates",
         "debug": "vite build --debug",
         "prod": "vite build",
         "prod-two-sites-example": "vite build && vite build --config vite.config.site2.js",
@@ -19,8 +19,8 @@
         "start": "ddev composer install && (yarn install && yarn run prod && yarn run init-clint) && git config core.hooksPath .githooks && chmod +x .githooks/post-merge && chmod +x .githooks/pre-push && node -e \"console.log('DONE! All ready to go!')\"",
         "googlefonts": "node googlefonts.js",
         "touch": "../craft project-config/touch",
-        "init-clint": "cd clint && yarn install && yarn run build",
-        "update": "cd clint && yarn start"
+        "init-clint": "cd ../clint && yarn install && yarn run build",
+        "update": "cd ../clint && yarn start"
     },
     "resolutions": {
         "sharp": "^0.35.4"


### PR DESCRIPTION
## The problem

`yarn watch` failed on a fresh clone:

```
node:internal/modules/cjs/loader:1386
  throw err;
  ^
Error: Cannot find module '../clint/dist/cli.js'
```

`clint/dist/` is a build artifact and is gitignored, so a fresh clone has no `cli.js`. `frontend/package.json` called it directly, so the command exited 1 and the `&& vite` never ran — the dev server refused to start, on a Node stack trace rather than a useful message.

**A second bug made it unrecoverable.** `init-clint` — the script that is supposed to build Clint, and what `yarn start` calls — ran `cd clint` from inside `frontend/`, resolving to `frontend/clint`, which does not exist. `update` had the same bug. So the bootstrap that would have produced `cli.js` had never worked.

## The fix

New `frontend/ensure-clint.js`: builds Clint once if `dist/cli.js` is missing, then forwards its arguments to the CLI. `watch` and `dev` now go through it, and `init-clint`/`update` use `cd ../clint`.

It **always exits 0**. Previously any Clint problem — missing, offline, corrupt — stopped frontend work outright. An advisory update check has no business blocking the dev server, so it is now a warning and Vite starts anyway.

## Verified

| Scenario | Result |
| --- | --- |
| `cli.js` already built | Silent, ~1.2s, check runs normally |
| Fresh clone, no `dist/` at all | Builds once, runs the check, exit 0 |
| `clint/` directory missing entirely | Warns, exit 0 — Vite still starts |
| `cli.js` present but crashing | Warns, exit 0 — Vite still starts |

## Ships as a Clint update

`20260902-build-the-clint-cli-on-demand-for-yarn-watch`, so existing projects get it. `ensure-clint.js` arrives through the normal frontend sync; the script changes are four literal `findAndReplace` rules.

Those rules were tested against develop's actual `frontend/package.json` using clint's real `replace-in-file`: pass 1 produces a byte-identical result to the file in this PR, pass 2 changes nothing (idempotent). The changelog flags that a project which has customised these scripts will not match the rules and needs a manual edit.

Follows the new manifest workflow from #700 — no `index.json` in this PR.

Fixes the `yarn watch` bootstrap; unrelated to #699 itself, which #700 resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)